### PR TITLE
Changed background tile attribution spelling

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -33,7 +33,7 @@ $viciCall = "<script type=\"text/javascript\">
                         maxZoom: 11
                     },
                     ESRI: {
-                        name: 'Esri WorldImagery',
+                        name: 'Esri World Imagery',
                         url: \"https://tiles.vici.org/world/{z}/{y}/{x}\",
                         attributions: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
                     }

--- a/public/item.php
+++ b/public/item.php
@@ -84,7 +84,7 @@ $(document).ready(function() {
                 maxZoom: 11
             },
             ESRI: {
-                name: 'Esri WorldImagery',
+                name: 'Esri World Imagery',
                 url: \"https://tiles.vici.org/world/{z}/{y}/{x}\",
                 attributions: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
             }

--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -31,10 +31,10 @@ function MapWidget(canvas, positionField, lng, lat, markerType) {
         OSM: {
             name: "OpenStreetMap",
             url: "https://tiles.vici.org/osm/{z}/{x}/{y}.png",
-            attributions: "© <a href=\"https://www.openstreetmap.org/copyright\">Open Streetmap Contributors</a> CC BY-SA"
+            attributions: "© <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a> CC BY-SA"
         },
         ESRI: {
-            name: "Esri WorldImagery",
+            name: "Esri World Imagery",
             url: "https://tiles.vici.org/world/{z}/{y}/{x}",
             attributions: "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
         }

--- a/public/novo.html
+++ b/public/novo.html
@@ -63,7 +63,7 @@
                         maxZoom: 11
                     },
                     ESRI: {
-                        name: 'Esri WorldImagery',
+                        name: 'Esri World Imagery',
                         url: "https://tiles.vici.org/world/{z}/{y}/{x}",
                         attributions: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
                     }


### PR DESCRIPTION
Changes attribution's spelling (casing, spacing).

For OpenStreetMap, see https://www.openstreetmap.org/copyright
<sub>under Trademarks; Trademark Policy [at] https://osmfoundation.org/wiki/Trademark_Policy</sub>
<sub>For questions, see the relevant section on above page. See also https://osmfoundation.org/wiki/Contact</sub>

<sub>Instances of this text on the openstreetmap.org website itself are subject to translation errors/vandalism. If you come across any translation errors, feel free to report them on its TranslateWiki page.</sub>

For Esri, see https://www.arcgis.com/home/item.html?id=86de95d4e0244cba80f0fa2c9403a7b2 (their official page)

cc @renevoorburg 